### PR TITLE
fix: disable fof/redis settings cache to avoid circular boot dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ composer update glowingblue/redis-setup
 php flarum cache:clear
 ```
 
+## Compatibility with `fof/redis`
+
+This extension depends on [`fof/redis`](https://github.com/FriendsOfFlarum/redis) and deliberately disables the **`settings` service** that `fof/redis` ≥ 1.1 provides.
+
+`fof/redis`'s settings service replaces Flarum's `SettingsRepositoryInterface` with a Redis-backed caching layer. However, this extension reads settings (e.g. which Redis services to enable) during its own boot sequence — *before* Redis is fully wired into the container. Enabling the Redis settings cache here would create a circular dependency: configuring Redis requires reading settings, but reading settings requires Redis.
+
+The `settings` service from `fof/redis` is therefore always disabled in this extension's extender. If you want Redis-backed settings caching, configure `fof/redis` directly in your project's root `extend.php` instead of using this extension.
+
 ## 🔗 Links
 
 -   [Flarum Discuss post](https://discuss.flarum.org/d/27455)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": "^8.1",
     "flarum/core": "^1.8.5",
-    "fof/redis": "^1.0"
+    "fof/redis": "^1.1.4"
   },
   "authors": [
     {

--- a/src/Extend/EnableRedis.php
+++ b/src/Extend/EnableRedis.php
@@ -31,7 +31,7 @@ class EnableRedis implements ExtenderInterface
 
 		/** @var Redis $redis */
 		$redis = (new Redis($config))
-			->disable($this->getDisabledServices());
+			->disable(['settings', ...$this->getDisabledServices()]);
 
 		$redis->extend($container, $extension);
 	}
@@ -88,36 +88,42 @@ class EnableRedis implements ExtenderInterface
 
 	public static function getHost(): string
 	{
-		return getenv('REDIS_HOST') ? getenv('REDIS_HOST') : '127.0.0.1';
+		return getenv('REDIS_HOST') ?: '127.0.0.1';
 	}
 
 	public static function getPassword(): ?string
 	{
-		return getenv('REDIS_PASSWORD') ? getenv('REDIS_PASSWORD') : null;
+		return getenv('REDIS_PASSWORD') ?: null;
 	}
 
 	public static function getPort(): string
 	{
-		return getenv('REDIS_PORT') ? getenv('REDIS_PORT') : '6379';
+		return getenv('REDIS_PORT') ?: '6379';
 	}
 
 	public static function getCacheDatabase(): int
 	{
-		return (int) getenv('REDIS_DATABASE_CACHE') ? getenv('REDIS_DATABASE_CACHE') : 1;
+		$val = getenv('REDIS_DATABASE_CACHE');
+
+		return $val !== false ? (int) $val : 1;
 	}
 
 	public static function getQueueDatabase(): int
 	{
-		return (int) getenv('REDIS_DATABASE_QUEUE') ? getenv('REDIS_DATABASE_QUEUE') : 2;
+		$val = getenv('REDIS_DATABASE_QUEUE');
+
+		return $val !== false ? (int) $val : 2;
 	}
 
 	public static function getSessionDatabase(): int
 	{
-		return (int) getenv('REDIS_DATABASE_SESSION') ? getenv('REDIS_DATABASE_SESSION') : 3;
+		$val = getenv('REDIS_DATABASE_SESSION');
+
+		return $val !== false ? (int) $val : 3;
 	}
 
 	public static function getPrefix(): string
 	{
-		return getenv('REDIS_PREFIX') ? getenv('REDIS_PREFIX') : 'flarum_';
+		return getenv('REDIS_PREFIX') ?: 'flarum_';
 	}
 }


### PR DESCRIPTION
## Summary

- Disables the `settings` service from `fof/redis` ≥ 1.1 in `EnableRedis::extend()`. This service replaces `SettingsRepositoryInterface` with a Redis-backed caching layer, which creates a circular dependency: this extension reads settings to determine which Redis services to enable, but those reads require Redis to already be wired into the container.
- Fixes a cast-precedence bug in the `getCacheDatabase()`, `getQueueDatabase()`, and `getSessionDatabase()` helpers — `(int) getenv(...) ? getenv(...) : N` was applying the cast to the ternary condition rather than the result, so `REDIS_DATABASE_*=0` would incorrectly return the default value instead of `0`.
- Documents the `settings` service incompatibility in the README, noting that users who want Redis-backed settings caching should configure `fof/redis` directly in their project's root `extend.php`.

## Test plan

- [ ] Install with `fof/redis` ≥ 1.1 and verify the extension boots without error
- [ ] Verify enabling/disabling cache, queue, and session via admin settings still works
- [ ] Verify `REDIS_DATABASE_*=0` correctly uses database `0` rather than the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)